### PR TITLE
add pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.pytest.ini_options]
+addopts = [
+    "--cache-clear", 
+    "--cov=fpu", 
+    "--cov-report=term-missing", 
+    "--cov-fail-under=90", 
+    "--color=auto", 
+    "-ra"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ pycodestyle==2.11.0
 pyflakes==3.1.0
 Pygments==2.15.0
 pytest==7.4.0
+pytest-cov==4.1.0
+pytest-lineno==0.0.1
 readme-renderer==24.0
 requests==2.31.0
 requests-toolbelt==0.9.1


### PR DESCRIPTION
This PR is related to issue #39. 

In the PR, 
- `pyproject.toml` is newly added to configure pytest. 
- added 90% coverage threshold based on issue #20.
- To make test output clean and compact, I don't intend to add `-v` option for verbosity.
- based on the configuration, the sample output with and without test errors look like the pictures below 
  - with test errors: 
    ![image](https://github.com/johnklee/fpu/assets/32351981/70d6e3b9-4dd5-4ca3-bb97-8fbdb8ef83ae)
  - without test errors: 
    ![Screenshot 2023-09-25 003018](https://github.com/johnklee/fpu/assets/32351981/71ec129b-dd20-4969-b3b1-32a8554aa50f)
- note: the `-ra` option is explained in the issue. 

With the `pytest-lineno` package, we can also simply `ctrl+click` to directly navigate to the test function where an error occurred. Otherwise, we may also refer to the test function name and navigate there manually. This should help local testing and also the potential pre-commit auto test in the future. 

Currently the total coverage is only 80%, which is below 90+%. This PR doesn't fix this error but help set up pytest config and standard output for future usage. The coverage rate error may be fixed via another PR. 