### PR TITLE
replace `pytest-lineno` and `pytest-cov` to `coverage` package, with more supports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ init:
 	pip install -r requirements.txt
 
 test:
-	pytest tests
+	- coverage run -m pytest tests
+	coverage report -m 
 
 dist: init test
 	rm -f dist/*

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ init:
 
 test:
 	- coverage run -m pytest tests
-	coverage report -m 
+	coverage report
 
 dist: init test
 	rm -f dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,32 @@
 [tool.pytest.ini_options]
 addopts = [
     "--cache-clear", 
-    "--cov=fpu", 
-    "--cov-report=term-missing", 
-    "--cov-fail-under=90", 
-    "--color=auto", 
     "--tb=line",
-    "-ra", 
+    "-ra"
 ]
+
+[tool.coverage.run]
+branch = true
+source = ["fpu/"]
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_also = [
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    "def __hash__",
+    "if self\\.debug",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
+
+    # Don't complain about abstract methods, they aren't run:
+    "@(abc\\.)?abstractmethod",
+    ]
+
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,6 @@ addopts = [
     "--cov-report=term-missing", 
     "--cov-fail-under=90", 
     "--color=auto", 
-    "-ra"
+    "--tb=line",
+    "-ra", 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,11 @@ fail_under=90
 # Regexes for lines to exclude from consideration
 exclude_also = [
     # Don't complain about missing debug-only code:
+    "if self[.]debug",
+
+    # Don't complain for trivial parts
     "def __repr__",
     "def __hash__",
-    "if self\\.debug",
 
     # Don't complain if tests don't hit defensive assertion code:
     "raise AssertionError",
@@ -30,5 +32,5 @@ exclude_also = [
     "if __name__ == .__main__.:",
 
     # Don't complain about abstract methods, they aren't run:
-    "@(abc\\.)?abstractmethod",
-    ]
+    "@(abc[.])?abstractmethod",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.pytest.ini_options]
 addopts = [
     "--cache-clear", 
+    "--color=auto",
     "--tb=line",
     "-ra"
 ]
@@ -10,6 +11,9 @@ branch = true
 source = ["fpu/"]
 
 [tool.coverage.report]
+show_missing = true
+# coverage threshold 
+fail_under=90
 # Regexes for lines to exclude from consideration
 exclude_also = [
     # Don't complain about missing debug-only code:
@@ -28,5 +32,3 @@ exclude_also = [
     # Don't complain about abstract methods, they aren't run:
     "@(abc\\.)?abstractmethod",
     ]
-
-ignore_errors = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ pyflakes==3.1.0
 Pygments==2.15.0
 pytest==7.4.0
 pytest-cov==4.1.0
-pytest-lineno==0.0.1
 readme-renderer==24.0
 requests==2.31.0
 requests-toolbelt==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bleach==3.3.0
 certifi==2023.7.22
 chardet==3.0.4
 charset-normalizer==3.2.0
+coverage==7.3.1
 docutils==0.14
 entrypoints==0.3
 exceptiongroup==1.1.3
@@ -17,7 +18,6 @@ pycodestyle==2.11.0
 pyflakes==3.1.0
 Pygments==2.15.0
 pytest==7.4.0
-pytest-cov==4.1.0
 readme-renderer==24.0
 requests==2.31.0
 requests-toolbelt==0.9.1


### PR DESCRIPTION
This is the 2nd PR related to issue #39. 

The PR
- adds the setting `tb=line` traceback, so we have the sample output shown below (the one line FAILURES section)
- removes the `pytest-lineno` package since we have the line number due to `tb=line`. 
- replaces the `pytest-cov` package with `coverage` package since it supports:
   - different report format output 
   - the ability to exclude some trivial code lines that are not covered in tests (e.g., `raise NotImplementedError` etc)
- update relevant setups in `pyproject.toml` and `Makefile` for the new package.

PS. `-` in Makefile means to continue the next line execution even if an error is encountered. ([Reference](https://www.math.utah.edu/docs/info/make_5.html#SEC46))

Example screenshot when 
with errors: 
![fail](https://github.com/johnklee/fpu/assets/32351981/fde53030-ba76-42db-95c3-bea1ee697244)
w/o errors:
![pass](https://github.com/johnklee/fpu/assets/32351981/1f2b3297-067a-4893-b537-63de3c0c9692)
