### PR TITLE
add `dist: jammy` in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: jammy
 
 python:
   - "3.8"


### PR DESCRIPTION
The PR is part of the issue #29 . 

The PR: 
- fixed Travis build fail on python 3.10 & 3.11 (not found error) by replacing default `dist: xenial` to `dist: jammy`. 

Eg, 
with the default `dist: xenial`: [A fail build](https://app.travis-ci.com/github/wkCircle/fpu/builds/266479510)
with the new `dist: jammy`: [A success build](https://app.travis-ci.com/github/wkCircle/fpu/builds/266480057)