### PR TITLE
Add badges and update ci-build workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: CI Build
 
 on: 
   pull_request: 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -35,7 +35,7 @@ jobs:
         run: make test 
 
       - name: Report Coveralls 
-        if: ${{ matrix.python-version }} == "3.8"
+        if: ${{ matrix.python-version == 3.8}}
         run: |
           coverage xml -o ".coverage.xml"
           curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz \

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,3 +30,12 @@ jobs:
       
       - name: Test fpu with pytest 
         run: make test 
+
+      - name: Report Coveralls 
+        if: ${{ matrix.python-version }} == "3.8"
+        run: |
+          coverage xml -o ".coverage.xml"
+          curl -sL https://coveralls.io/coveralls-linux.tar.gz | tar -xz \
+          && ./coveralls -f ".coverage.xml"
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,9 +1,6 @@
 name: CI Build
 
 on: 
-  push:
-    branches:
-      - 19-badges
   pull_request: 
     branches: 
       - master

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,6 +1,9 @@
 name: CI Build
 
 on: 
+  push:
+    branches:
+      - 19-badges
   pull_request: 
     branches: 
       - master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CI-Build](https://github.com/johnklee/fpu/actions/workflows/ci-build.yml/badge.svg?branch=master)](https://github.com/johnklee/fpu/actions/workflows/ci-build.yml)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fpu)
+[![Coverage Status](https://coveralls.io/repos/github/wkCircle/fpu/badge.svg?branch=19-badges)](https://coveralls.io/github/wkCircle/fpu?branch=19-badges)
 
 Overview and Table of Contents
 ==========================

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI-Build](https://github.com/johnklee/fpu/actions/workflows/ci-build.yml/badge.svg?branch=master)](https://github.com/johnklee/fpu/actions/workflows/ci-build.yml)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fpu)
 
 Overview and Table of Contents

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.com/johnklee/fpu.svg?branch=master)](https://travis-ci.com/johnklee/fpu)<br/>
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fpu)
+
 Overview and Table of Contents
 ==========================
 This package is used as utility to support more thorough FP (functional programming) functionalities in Python. For more, you can refer to [FPU.pptx](https://github.com/johnklee/fpu/blob/master/docs/FPU.pptx)

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,41 @@
 from __future__ import print_function
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-import io
-import codecs
-import os
-import sys
-
+from pathlib import Path
 import fpu
 
-here = os.path.abspath(os.path.dirname(__file__))
 
 def read(*parts):
-    # intentionally *not* adding an encoding option to open
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+  return Path(__file__).parent.joinpath(*parts).read_text()
+
 
 long_description = read('README.md')
-
-setup(name='fpu',
-      version=fpu.__version__,
-      description='Functional Programming Utility',
-      url='https://github.com/johnklee/fpu',
-      author='johnklee',
-      author_email='puremonkey2007@gmail.com',
-      tests_require=['pytest'],
-      long_description_content_type='text/markdown',
-      long_description=long_description,
-      license='MIT',
-      packages=['fpu'],
-      classifiers = [
-        'Programming Language :: Python :: 3',
-        'Development Status :: 3 - Alpha',
-        'Natural Language :: English',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-      ],
-      zip_safe=False)
+setup(
+  name='fpu',
+  version=fpu.__version__,
+  description='Functional Programming Utility',
+  url='https://github.com/johnklee/fpu',
+  author='johnklee',
+  author_email='puremonkey2007@gmail.com',
+  tests_require=['pytest'],
+  long_description_content_type='text/markdown',
+  long_description=long_description,
+  license='MIT',
+  packages=['fpu'],
+  classifiers=[
+    'Natural Language :: English',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Development Status :: 3 - Alpha',
+    'Environment :: Web Environment',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: OS Independent',
+    'Topic :: Software Development :: Libraries :: Python Modules',
+  ],
+  zip_safe=False
+)


### PR DESCRIPTION
This PR is related to #19 

The PR 
- renames the workflow from `Python Package` to `CI Build`, 
- Adds CI-build workflow status badge, 
- Adds Coveralls step in CI-build (the step is run only when python==3.8 to avoid duplicates), 
- Adds Coveralls coverage badge, 
- Updates `setup.py` to simplify code and add more specific supported python languages, 
- Adds Pypi's supported python version badge.

Build success: 
A successful workflow run on my forked repo can be seen [here](https://github.com/wkCircle/fpu/actions/runs/6498008495).
A sample demo of the readme badge output can be seen [here](https://github.com/wkCircle/fpu/tree/19-badges#readme).
A sample demo of coveralls webpage can be seen [here](https://coveralls.io/github/wkCircle/fpu?branch=19-badges).

Issues: 

1. coveralls requires `secrets.COVERALLS_REPO_TOKEN` (as seen in ci-build.yml). @johnklee needs to set this secret up following [Coveralls Official Tutorial](https://docs.coveralls.io/).
2. the README's current coveralls badge link connects to `wkCircle/fpu/badge.svg?branch=19-badges`, @johnklee needs to change it to `johnklee/fpu/badge.svg?branch=master`.

I didn't do this because I wanna show the demo and at the same time I don't have the permission of the original repo.

Question: 
Is there a way that you can download the branch `19-badges` and continue to work on it, so you can test everything on your side with your permission?